### PR TITLE
#165626472 feature: admin can only view staffuser list

### DIFF
--- a/server/controllers/adminRoute.js
+++ b/server/controllers/adminRoute.js
@@ -20,3 +20,6 @@ router.use(bodyParser.json({ type: 'application/json'}));
 
 
 router.post('/admin/createstaff', jwtAdminVerify, adminQueries.createStaffAdmin)
+
+//All Staff
+router.get('/staff', jwtAdminVerify, adminQueries.getStaffUsers)


### PR DESCRIPTION
What does this PR do?
admin can only view staffuser list

Description of Task to be completed?
N/A

How should this be manually tested?
Clone the directory from git
npm init & npm start
using postman access the url at POST /api/v1/staff
Any background context you want to provide?
N/A

What are the relevant pivotal tracker stories?
DELIVER #165626472